### PR TITLE
35: Use Microprofile BOM/POM

### DIFF
--- a/microprofile-sample-canonical/pom.xml
+++ b/microprofile-sample-canonical/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.microprofile.sample</groupId>
+        <groupId>io.microprofile.sample</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>canonical</artifactId>
     <packaging>${packaging.type}</packaging>
-    <name>Microprofile Samples :: Canonical</name>
+    <name>MicroProfile Samples :: Canonical</name>
 
     <dependencies>
         <!-- JBoss Logging required due to older version from resteasy client -->
@@ -39,10 +39,11 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
-        <!-- JAVA EE -->
+        <!-- MicroProfile -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>io.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+             <type>pom</type>
         </dependency>
         <!-- TEST -->
         <dependency>

--- a/microprofile-sample-swagger/pom.xml
+++ b/microprofile-sample-swagger/pom.xml
@@ -24,14 +24,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.microprofile.sample</groupId>
+        <groupId>io.microprofile.sample</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>swagger</artifactId>
     <packaging>${packaging.type}</packaging>
-    <name>Microprofile Samples :: Swagger</name>
+    <name>MicroProfile Samples :: Swagger</name>
 
     <dependencies>
         <!-- JBoss Logging required due to older version from resteasy client -->
@@ -39,10 +39,11 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
-        <!-- JAVA EE -->
+        <!-- MicroProfile -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>io.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+             <type>pom</type>
         </dependency>
         <!-- OTHERS -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,15 @@
     xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.microprofile.sample</groupId>
+    <groupId>io.microprofile.sample</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
-    <name>Microprofile Samples</name>
+    <name>MicroProfile Samples</name>
 
     <inceptionYear>2016</inceptionYear>
     <organization>
-        <name>Eclipse Microprofile</name>
+        <name>Eclipse MicroProfile</name>
         <url>http://www.microprofile.io</url>
     </organization>
 
@@ -41,7 +41,7 @@
     </modules>
 
     <properties>
-        <version.javaee>7.0</version.javaee>
+        <version.microprofile>1.0.0</version.microprofile>
         <version.resteasy>3.0.18.Final</version.resteasy>
         <version.swagger>1.5.9</version.swagger>
         <skipLicenseCheck>false</skipLicenseCheck>
@@ -89,12 +89,12 @@
                 <artifactId>jboss-logging</artifactId>
                 <version>${version.jboss-logging}</version>
             </dependency>
-            <!-- JAVA EE -->
+            <!-- MicroProfile -->
             <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-api</artifactId>
-                <version>${version.javaee}</version>
-                <scope>provided</scope>
+                <groupId>io.microprofile</groupId>
+                <artifactId>microprofile</artifactId>
+                <version>${version.microprofile}</version>
+                <type>pom</type>
             </dependency>
 
             <!-- WILDFLY SWARM -->
@@ -147,6 +147,32 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <!-- Additional repositories -->
+    <!-- Helps to resolve Parent POM and Snapshot artifacts -->
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>http://jcenter.bintray.com</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-release</id>
+            <name>libs-release</name>
+            <url>http://oss.jfrog.org/artifactory/libs-release</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>bintray-snapshot</id>
+            <name>libs-snapshot</name>
+            <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
Successfully switched `java-ee-api` 7.0 to `microprofile` 1.0.0. Everything builds as it did before. 
For consistency I changed the groupId to `io.microprofile` for 1.0.0, the packages are as they were but we cannot rewrite history so it should be fine.

Task-Url: https://github.com/eclipse/microprofile-samples/issues/35