### PR TITLE
Add git clone command to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,6 +31,10 @@ Give different examples using the MicroProfile :
 
 ## Building
 
+Clone the git repository:
+
+* `git clone https://github.com/eclipse/microprofile-samples.git`
+
 To build these examples you can just :
 
 * `mvn clean install` does not run any test


### PR DESCRIPTION
Since the README is exposed as a webpage under https://microprofile.io/project/eclipse/microprofile-samples, this helps those hitting that URL to follow all the steps without having to visit the actual GitHub repository.